### PR TITLE
Update TextInput placeholder text color default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cosmictiger/ui-native",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Cosmic UI Internal use",
   "author": "Cosmic Tiger x Pace",
   "type": "module",

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -23,7 +23,7 @@ const TextInput = React.forwardRef<
   const cursorColor = getColor(theme, props.cursorColor || "primary");
   const placeholderTextColor = getColor(
     theme,
-    props.placeholderTextColor || "lightGray",
+    props.placeholderTextColor || "primary",
   );
   const selectionColor = getColor(theme, props.selectionColor || "primary");
 


### PR DESCRIPTION
- Updated package.json version from 0.2.1 to 0.2.2.
- Changed TextInput component's placeholder text color from lightGray to primary.